### PR TITLE
Added source include parameter to "get" node

### DIFF
--- a/get.html
+++ b/get.html
@@ -6,6 +6,7 @@
           documentId: {value: ''},
           documentIndex: {value: ''},
           documentType: {value: ''},
+          includeFields: {value: ''},
           server: {value:"", type:"remote-server"}
         },
         color:'#C0DEED',
@@ -29,12 +30,16 @@
         <input type="text" id="node-input-documentId" />
     </div>
     <div class="form-row">
-        <label for="node-input-index"><i class="icon-book"></i> Index</label>
+        <label for="node-input-documentIndex"><i class="icon-book"></i> Index</label>
         <input type="text" id="node-input-documentIndex" />
     </div>
     <div class="form-row">
         <label for="node-input-documentType"><i class="fa fa-cube"></i> Type</label>
         <input type="text" id="node-input-documentType" />
+    </div>
+    <div class="form-row">
+        <label for="node-input-includeFields"><i class="fa fa-bars"></i> Return Fields</label>
+        <input type="text" id="node-input-includeFields" placeholder="Leave blank for all" />
     </div>
     <div class="form-row">
         <label for="node-input-server"><i class="fa fa-plug"></i> Server</label>

--- a/get.js
+++ b/get.js
@@ -16,6 +16,7 @@ module.exports = function(RED) {
       var documentId = config.documentId;
       var documentIndex = config.documentIndex;
       var documentType = config.documentType;
+      var includeFields = config.includeFields;
 
       // check for overriding message properties
       if (msg.hasOwnProperty("documentId")) {
@@ -27,12 +28,20 @@ module.exports = function(RED) {
       if (msg.hasOwnProperty("documentType")) {
         documentType = msg.documentType;
       }
+      if (msg.hasOwnProperty("includeFields")) {
+        includeFields = msg.includeFields;
+      }
 
-      // construct the search params
+      if (typeof includeFields !== "undefined" && includeFields.indexOf(",") > 0) {
+        includeFields = includeFields.split(",");
+      }
+
+        // construct the search params
       var params = {
         index: documentIndex,
         type: documentType,
-        id: documentId
+        id: documentId,
+        _sourceInclude: includeFields
       };
 
       client.get(params).then(function (resp) {

--- a/search.html
+++ b/search.html
@@ -44,7 +44,7 @@
         <input type="text" id="node-input-sort" placeholder="Leave blank to sort by score" />
     </div>
     <div class="form-row">
-        <label for="node-input-index"><i class="icon-book"></i> Index</label>
+        <label for="node-input-documentIndex"><i class="icon-book"></i> Index</label>
         <input type="text" id="node-input-documentIndex" />
     </div>
     <div class="form-row">

--- a/search.js
+++ b/search.js
@@ -40,6 +40,10 @@ module.exports = function (RED) {
                 includeFields = msg.includeFields;
             }
 
+            if (typeof includeFields !== "undefined" && includeFields.indexOf(",") > 0) {
+                includeFields = includeFields.split(",");
+            }
+
             // construct the search params
             var params = {
                 size: maxResults,


### PR DESCRIPTION
Please find a summary of the proposed changes:
- Added the `_sourceInclude` parameter to the `get` node.
- Fixed a typo in the `_sourceInclude` label of the `search` node.
- For both `_sourceInclude` parameters, added the possibility to pass several comma-separated fields, which wasn't possible before.
